### PR TITLE
fix: resolve static files mounting error during tests

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -116,4 +116,7 @@ class DevStaticFiles(StaticFiles):
     
     
 # Serve static files for the frontend
-app.mount("/", StaticFiles(directory="../frontend", html=True), name="static")
+# Use absolute path and make it optional during testing
+frontend_path = Path(__file__).parent.parent / "frontend"
+if frontend_path.exists():
+    app.mount("/", StaticFiles(directory=str(frontend_path), html=True), name="static")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,8 @@ def client():
 @pytest.fixture
 async def async_client():
     """Create an async test client for the FastAPI app."""
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    from httpx import ASGITransport
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
         yield ac
 
 


### PR DESCRIPTION
Fixes the ImportError that occurred when running tests after test framework introduction.

The issue was caused by the relative path '../frontend' being resolved relative to the test execution context rather than the backend directory where app.py is located.

Changes:
- Use absolute path for frontend directory based on app.py location
- Make static files mounting conditional on directory existence

Closes #3

Generated with [Claude Code](https://claude.ai/code)